### PR TITLE
Updates exifr require to be compatible with 1.3.0

### DIFF
--- a/lib/jekyll-exiftag.rb
+++ b/lib/jekyll-exiftag.rb
@@ -24,7 +24,7 @@
 # These paths are relative to your sites root. Don't add leading and trailing slashes.
 #
 
-require 'exifr'
+require 'exifr/jpeg'
 
 module Jekyll
   class ExifTag < Liquid::Tag


### PR DESCRIPTION
Exifr 1.3.0 needs jpeg or tiff be specified in the require statement to
work.